### PR TITLE
fix(properties): remove comments breaking multi document properties

### DIFF
--- a/src/main/resources/application-auth.properties
+++ b/src/main/resources/application-auth.properties
@@ -19,7 +19,6 @@ bpdm.security.refresh-url=${bpdm.security.token-url}
 springdoc.swagger-ui.oauth.client-id=BPDM-Swagger-Dev
 #---
 spring.config.activate.on-profile=local_auth
-#As default
 #---
 spring.config.activate.on-profile=dev_auth,int_auth
 bpdm.security.enabled=true

--- a/src/main/resources/application-persist.properties
+++ b/src/main/resources/application-persist.properties
@@ -15,7 +15,6 @@ spring.flyway.enabled=true
 spring.flyway.schemas=bpdm
 #---
 spring.config.activate.on-profile=local_persist
-#As default
 #---
 spring.config.activate.on-profile=dev_persist,int_persist
 bpdm.datasource.host=${BPDM_DB_HOST}


### PR DESCRIPTION
from https://docs.spring.io/spring-boot/docs/2.7.x/reference/htmlsingle/#features.external-config.files.multi-document

"Property file separators must not have any leading whitespace and must have exactly three hyphen characters. The lines immediately before and after the separator must not be comments."