### PR TITLE
refactor(openapi): remove spaces from schema names

### DIFF
--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/AddressVersionDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/AddressVersionDto.kt
@@ -23,7 +23,7 @@ import com.neovisionaries.i18n.LanguageCode
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.model.CharacterSet
 
-@Schema(name = "Address Version", description = "Localization record for an address")
+@Schema(name = "AddressVersion", description = "Localization record for an address")
 data class AddressVersionDto(
     @Schema(description = "Character set in which the address is written", defaultValue = "UNDEFINED")
     val characterSet: CharacterSet = CharacterSet.UNDEFINED,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/AdministrativeAreaDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/AdministrativeAreaDto.kt
@@ -22,7 +22,7 @@ package org.eclipse.tractusx.bpdm.common.dto
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.model.AdministrativeAreaType
 
-@Schema(name = "Administrative Area", description = "Areas such as country regions or counties")
+@Schema(name = "AdministrativeArea", description = "Areas such as country regions or counties")
 data class AdministrativeAreaDto(
     @Schema(description = "Full name of the area")
     val value: String,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/BankAccountDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/BankAccountDto.kt
@@ -22,7 +22,7 @@ package org.eclipse.tractusx.bpdm.common.dto
 import com.neovisionaries.i18n.CurrencyCode
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(name = "Bank Account", description = "Bank account record of a business partner")
+@Schema(name = "BankAccount", description = "Bank account record of a business partner")
 data class BankAccountDto(
     @Schema(description = "Trust scores for the account", defaultValue = "[]")
     val trustScores: Collection<Float> = emptyList(),

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/BusinessStatusDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/BusinessStatusDto.kt
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.model.BusinessStatusType
 import java.time.LocalDateTime
 
-@Schema(name = "Business Status", description = "Status record for a business partner")
+@Schema(name = "BusinessStatus", description = "Status record for a business partner")
 data class BusinessStatusDto(
     @Schema(description = "Exact, official denotation of the status")
     val officialDenotation: String?,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/GeoCoordinateDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/GeoCoordinateDto.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.common.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(name = "Geo Coordinates", description = "Geo coordinates record for an address")
+@Schema(name = "GeoCoordinates", description = "Geo coordinates record for an address")
 data class GeoCoordinateDto(
     @Schema(description = "Longitude coordinate")
     val longitude: Float,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/LegalEntityDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/LegalEntityDto.kt
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.model.BusinessPartnerType
 
-@Schema(name = "Legal Entity")
+@Schema(name = "LegalEntity")
 data class LegalEntityDto(
     @ArraySchema(arraySchema = Schema(description = "Additional identifiers (except BPN)", required = false))
     val identifiers: Collection<IdentifierDto> = emptyList(),

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/PostalDeliveryPointDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/PostalDeliveryPointDto.kt
@@ -22,7 +22,7 @@ package org.eclipse.tractusx.bpdm.common.dto
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.model.PostalDeliveryPointType
 
-@Schema(name = "Postal Delivery Point", description = "Postal delivery point record for an address")
+@Schema(name = "PostalDeliveryPoint", description = "Postal delivery point record for an address")
 data class PostalDeliveryPointDto(
     @Schema(description = "Full name of the delivery point")
     val value: String,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/request/AddressPartnerSearchRequest.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/request/AddressPartnerSearchRequest.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.common.dto.request
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(name = "Address Partner Search Request", description = "Request for searching business partners of type address by parent BPNs")
+@Schema(name = "AddressPartnerSearchRequest", description = "Request for searching business partners of type address by parent BPNs")
 data class AddressPartnerSearchRequest(
     @Schema(description = "Filter by Business Partner Numbers of legal entities which are at that address")
     val legalEntities: Collection<String> = emptyList(),

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AddressBpnResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AddressBpnResponse.kt
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import io.swagger.v3.oas.annotations.media.Schema
 
 @JsonDeserialize(using = AddressBpnResponseDeserializer::class)
-@Schema(name = "Address Bpn Response", description = "Localized address record of a business partner")
+@Schema(name = "AddressBpnResponse", description = "Localized address record of a business partner")
 data class AddressBpnResponse(
     @Schema(description = "Business Partner Number, main identifier value for addresses")
     val bpn: String,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AddressPartnerResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AddressPartnerResponse.kt
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import io.swagger.v3.oas.annotations.media.Schema
 
 @JsonDeserialize(using = AddressPartnerResponse.CustomDeserializer::class)
-@Schema(name = "Address Partner Response", description = "Business partner of type address")
+@Schema(name = "AddressPartnerResponse", description = "Business partner of type address")
 data class AddressPartnerResponse(
     @Schema(description = "Business Partner Number of this legal entity")
     val bpn: String,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AddressPartnerSearchResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AddressPartnerSearchResponse.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.common.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(name = "Address Partner Search Response", description = "Business partner of type address with parent reference")
+@Schema(name = "AddressPartnerSearchResponse", description = "Business partner of type address with parent reference")
 data class AddressPartnerSearchResponse(
     val address: AddressPartnerResponse,
     @Schema(description = "Business Partner Number of the related legal entity")

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AddressResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AddressResponse.kt
@@ -27,7 +27,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameDto
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameUrlDto
 import org.eclipse.tractusx.bpdm.common.model.AddressType
 
-@Schema(name = "Address Response", description = "Localized address record of a business partner")
+@Schema(name = "AddressResponse", description = "Localized address record of a business partner")
 data class AddressResponse(
     @Schema(description = "Language and character set the address is written in")
     val version: AddressVersionResponse,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AddressVersionResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AddressVersionResponse.kt
@@ -24,7 +24,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameDto
 import org.eclipse.tractusx.bpdm.common.model.CharacterSet
 
-@Schema(name = "Address Version Response", description = "Localization record of an address")
+@Schema(name = "AddressVersionResponse", description = "Localization record of an address")
 data class AddressVersionResponse(
     @Schema(description = "Character set in which the address is written")
     val characterSet: TypeKeyNameDto<CharacterSet>,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AdministrativeAreaResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/AdministrativeAreaResponse.kt
@@ -25,7 +25,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameDto
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameUrlDto
 import org.eclipse.tractusx.bpdm.common.model.AdministrativeAreaType
 
-@Schema(name = "Administrative Area Response", description = "Area of an address such as country region or county")
+@Schema(name = "AdministrativeAreaResponse", description = "Area of an address such as country region or county")
 data class AdministrativeAreaResponse (
     @Schema(description = "Full name of the area")
     val value: String,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/BankAccountResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/BankAccountResponse.kt
@@ -23,7 +23,7 @@ import com.neovisionaries.i18n.CurrencyCode
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameDto
 
-@Schema(name = "Bank Account Response", description = "Bank account record for a business partner")
+@Schema(name = "BankAccountResponse", description = "Bank account record for a business partner")
 data class BankAccountResponse(
     @Schema(description = "Trust scores for the account", defaultValue = "[]")
     val trustScores: Collection<Float> = emptyList(),

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/BusinessStatusResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/BusinessStatusResponse.kt
@@ -24,7 +24,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameUrlDto
 import org.eclipse.tractusx.bpdm.common.model.BusinessStatusType
 import java.time.LocalDateTime
 
-@Schema(name = "Business Status Response", description = "Status of a business partner")
+@Schema(name = "BusinessStatusResponse", description = "Status of a business partner")
 data class BusinessStatusResponse(
     @Schema(description = "Exact, official denotation of the status")
     val officialDenotation: String?,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/ClassificationResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/ClassificationResponse.kt
@@ -22,7 +22,7 @@ package org.eclipse.tractusx.bpdm.common.dto.response
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeNameUrlDto
 
-@Schema(name = "Classification Response", description = "Classification record of a business partner")
+@Schema(name = "ClassificationResponse", description = "Classification record of a business partner")
 data class ClassificationResponse(
     val value: String? = null,
     val code: String? = null,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/IdentifierResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/IdentifierResponse.kt
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameDto
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameUrlDto
 
-@Schema(name = "Identifier Response", description = "Identifier record of a business partner")
+@Schema(name = "IdentifierResponse", description = "Identifier record of a business partner")
 data class IdentifierResponse(
     @Schema(description = "Value of the identifier")
     val value: String,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/LegalAddressSearchResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/LegalAddressSearchResponse.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.common.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(name = "Legal Address Search Response", description = "Legal address record with parent BPN")
+@Schema(name = "LegalAddressSearchResponse", description = "Legal address record with parent BPN")
 data class LegalAddressSearchResponse(
     @Schema(description = "BPNL of the legal entity this legal address belongs to")
     val legalEntity: String,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/LegalEntityPartnerResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/LegalEntityPartnerResponse.kt
@@ -29,7 +29,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 
 @JsonDeserialize(using = LegalEntityPartnerResponse.CustomDeserializer::class)
-@Schema(name = "Legal Entity Partner Response", description = "Business partner of type legal entity with currentness")
+@Schema(name = "LegalEntityPartnerResponse", description = "Business partner of type legal entity with currentness")
 data class LegalEntityPartnerResponse(
     @Schema(description = "Business Partner Number of this legal entity")
     val bpn: String,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/LegalEntityResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/LegalEntityResponse.kt
@@ -25,7 +25,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameDto
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameUrlDto
 import org.eclipse.tractusx.bpdm.common.model.BusinessPartnerType
 
-@Schema(name = "Legal Entity Response", description = "Legal entity record")
+@Schema(name = "LegalEntityResponse", description = "Legal entity record")
 data class LegalEntityResponse(
     @ArraySchema(arraySchema = Schema(description = "All identifiers of the business partner, including BPN information"))
     val identifiers: Collection<IdentifierResponse> = emptyList(),

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/LegalFormResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/LegalFormResponse.kt
@@ -24,7 +24,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameDto
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeNameUrlDto
 
-@Schema(name = "Legal Form Response", description = "Legal form a business partner can have")
+@Schema(name = "LegalFormResponse", description = "Legal form a business partner can have")
 data class LegalFormResponse(
     @Schema(description = "Unique key to be used for reference")
     val technicalKey: String,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/LocalityResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/LocalityResponse.kt
@@ -25,7 +25,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameDto
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameUrlDto
 import org.eclipse.tractusx.bpdm.common.model.LocalityType
 
-@Schema(name = "Locality Response", description = "Locality record of an address such as city, block or district")
+@Schema(name = "LocalityResponse", description = "Locality record of an address such as city, block or district")
 data class LocalityResponse (
     @Schema(description = "Full name of the locality")
     val value: String,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/MainAddressSearchResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/MainAddressSearchResponse.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.common.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(name = "Main Address Search Response", description = "Main address record with parent BPN")
+@Schema(name = "MainAddressSearchResponse", description = "Main address record with parent BPN")
 data class MainAddressSearchResponse(
     @Schema(description = "BPNS of the site this main address belongs to")
     val site: String,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/NameResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/NameResponse.kt
@@ -25,7 +25,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameDto
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameUrlDto
 import org.eclipse.tractusx.bpdm.common.model.NameType
 
-@Schema(name = "Name Response", description = "Name record of a business partner")
+@Schema(name = "NameResponse", description = "Name record of a business partner")
 data class NameResponse (
     @Schema(description = "Full name")
     val value: String,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/PostCodeResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/PostCodeResponse.kt
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameUrlDto
 import org.eclipse.tractusx.bpdm.common.model.PostCodeType
 
-@Schema(name = "Postcode Response", description = "Postcode record of an address")
+@Schema(name = "PostcodeResponse", description = "Postcode record of an address")
 data class PostCodeResponse(
     @Schema(description = "Full postcode denotation")
     val value: String,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/PostalDeliveryPointResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/PostalDeliveryPointResponse.kt
@@ -25,7 +25,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameDto
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameUrlDto
 import org.eclipse.tractusx.bpdm.common.model.PostalDeliveryPointType
 
-@Schema(name = "Postal Delivery Point Response", description = "Postal delivery point record of an address")
+@Schema(name = "PostalDeliveryPointResponse", description = "Postal delivery point record of an address")
 data class PostalDeliveryPointResponse(
     @Schema(description = "Full denotation of the delivery point")
     val value: String,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/PremiseResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/PremiseResponse.kt
@@ -25,7 +25,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameDto
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameUrlDto
 import org.eclipse.tractusx.bpdm.common.model.PremiseType
 
-@Schema(name = "Premise Response", description = "Premise record of an address such as building, room or floor")
+@Schema(name = "PremiseResponse", description = "Premise record of an address such as building, room or floor")
 data class PremiseResponse (
     @Schema(description = "Full denotation of the premise")
     val value: String,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/RelationResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/RelationResponse.kt
@@ -25,7 +25,7 @@ import org.eclipse.tractusx.bpdm.common.model.RelationClass
 import org.eclipse.tractusx.bpdm.common.model.RelationType
 import java.time.LocalDateTime
 
-@Schema(name = "Relation Response", description = "Directed relation between two business partners")
+@Schema(name = "RelationResponse", description = "Directed relation between two business partners")
 data class RelationResponse (
     @Schema(description = "Class of relation like Catena, LEI or DNB relation")
     val relationClass: TypeKeyNameDto<RelationClass>,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/SitePartnerResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/SitePartnerResponse.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.common.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(name = "Site Partner Response", description = "Business partner of type site")
+@Schema(name = "SitePartnerResponse", description = "Business partner of type site")
 data class SitePartnerResponse(
     @Schema(description = "Business Partner Number, main identifier value for sites")
     val bpn: String,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/SitePartnerSearchResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/SitePartnerSearchResponse.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.common.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(name = "Site Partner Search Response", description = "Business partner of type site with parent BPN")
+@Schema(name = "SitePartnerSearchResponse", description = "Business partner of type site with parent BPN")
 data class SitePartnerSearchResponse(
     @Schema(description = "Site properties")
     val site: SitePartnerResponse,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/SiteResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/SiteResponse.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.common.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(name = "Site Response", description = "Site of a legal entity")
+@Schema(name = "SiteResponse", description = "Site of a legal entity")
 data class SiteResponse(
     @Schema(description = "Site name")
     val name: String

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/ThoroughfareResponse.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/ThoroughfareResponse.kt
@@ -25,7 +25,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameDto
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeKeyNameUrlDto
 import org.eclipse.tractusx.bpdm.common.model.ThoroughfareType
 
-@Schema(name = "Thoroughfare Response", description = "Thoroughfare record of an address such as street, square or industrial zone")
+@Schema(name = "ThoroughfareResponse", description = "Thoroughfare record of an address such as street, square or industrial zone")
 data class ThoroughfareResponse(
     @Schema(description = "Full denotation of the thoroughfare")
     val value: String,

--- a/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/type/TypeNameUrlDto.kt
+++ b/bpdm-common/src/main/kotlin/org/eclipse/tractusx/bpdm/common/dto/response/type/TypeNameUrlDto.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.common.dto.response.type
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(name = "Named Type With Link", description = "General type with name and URL link for further information")
+@Schema(name = "NamedTypeWithLink", description = "General type with name and URL link for further information")
 data class TypeNameUrlDto(
     @Schema(description = "Name of the type")
     val name: String,

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/dto/LegalEntityGateInput.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/dto/LegalEntityGateInput.kt
@@ -29,7 +29,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
 
 @JsonDeserialize(using = LegalEntityGateInputDeserializer::class)
-@Schema(name = "Legal Entity Gate Input", description = "Legal entity with external id")
+@Schema(name = "LegalEntityGateInput", description = "Legal entity with external id")
 data class LegalEntityGateInput(
     @Schema(description = "ID the record has in the external system where the record originates from", required = true)
     val externalId: String,

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/dto/LegalEntityGateOutput.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/dto/LegalEntityGateOutput.kt
@@ -31,7 +31,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.AddressResponse
 import org.eclipse.tractusx.bpdm.common.dto.response.LegalEntityResponse
 
 @JsonDeserialize(using = LegalEntityGateOutputDeserializer::class)
-@Schema(name = "Legal Entity Gate Output", description = "Legal entity with references")
+@Schema(name = "LegalEntityGateOutput", description = "Legal entity with references")
 data class LegalEntityGateOutput(
     @JsonUnwrapped
     val legalEntity: LegalEntityResponse,

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/dto/SiteGateOutput.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/dto/SiteGateOutput.kt
@@ -30,7 +30,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.AddressResponse
 import org.eclipse.tractusx.bpdm.common.dto.response.SiteResponse
 
 @JsonDeserialize(using = SiteGateOutputDeserializer::class)
-@Schema(name = "Site Gate Output", description = "Site with legal entity reference.")
+@Schema(name = "SiteGateOutput", description = "Site with legal entity reference.")
 data class SiteGateOutput(
     @JsonUnwrapped
     val site: SiteResponse,

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/dto/request/PaginationStartAfterRequest.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/dto/request/PaginationStartAfterRequest.kt
@@ -24,7 +24,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import javax.validation.constraints.Max
 import javax.validation.constraints.Min
 
-@Schema(name = "Pagination Start After Request", description = "Defines pagination information for requesting collection results")
+@Schema(name = "PaginationStartAfterRequest", description = "Defines pagination information for requesting collection results")
 data class PaginationStartAfterRequest(
     @field:Parameter(
         description = "Value used to indicate which page to retrieve. When this value is not provided, the first page is returned." +

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/AddressPartnerCreateRequest.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/AddressPartnerCreateRequest.kt
@@ -29,7 +29,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.AddressDto
 
 @JsonDeserialize(using = AddressPartnerCreateRequest.CustomDeserializer::class)
-@Schema(name = "Address Partner Create Request", description = "Request for creating new business partner record of type address")
+@Schema(name = "AddressPartnerCreateRequest", description = "Request for creating new business partner record of type address")
 data class AddressPartnerCreateRequest(
     @JsonUnwrapped
     val properties: AddressDto,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/AddressPartnerUpdateRequest.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/AddressPartnerUpdateRequest.kt
@@ -29,7 +29,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.AddressDto
 
 @JsonDeserialize(using = AddressPartnerUpdateRequest.CustomDeserializer::class)
-@Schema(name = "Address Partner Update Request", description = "Request for updating a business partner record of type address")
+@Schema(name = "AddressPartnerUpdateRequest", description = "Request for updating a business partner record of type address")
 data class AddressPartnerUpdateRequest(
     @Schema(description = "Business Partner Number of this address")
     val bpn: String,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/AddressPropertiesSearchRequest.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/AddressPropertiesSearchRequest.kt
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.boot.context.properties.ConstructorBinding
 
-@Schema(name = "Address Properties Search Request", description = "Contains keywords used for searching in business partner properties")
+@Schema(name = "AddressPropertiesSearchRequest", description = "Contains keywords used for searching in business partner properties")
 data class AddressPropertiesSearchRequest @ConstructorBinding constructor(
     @field:Parameter(description = "Filter business partners by administrative area name")
     var administrativeArea: String? = null,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/IdentifiersSearchRequest.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/IdentifiersSearchRequest.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.dto.request
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(name = "Identifiers Search Request", description = "Contains identifiers to search legal entities by")
+@Schema(name = "IdentifiersSearchRequest", description = "Contains identifiers to search legal entities by")
 data class IdentifiersSearchRequest(
     @Schema(description = "Technical key of the type to which the identifiers belongs to")
     val idType: String,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/LegalEntityPartnerCreateRequest.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/LegalEntityPartnerCreateRequest.kt
@@ -29,7 +29,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
 
 @JsonDeserialize(using = LegalEntityPartnerCreateRequest.CustomDeserializer::class)
-@Schema(name = "Legal Entity Partner Create Request", description = "Request for creating new business partner record of type legal entity")
+@Schema(name = "LegalEntityPartnerCreateRequest", description = "Request for creating new business partner record of type legal entity")
 data class LegalEntityPartnerCreateRequest(
     @JsonUnwrapped
     val properties: LegalEntityDto,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/LegalEntityPartnerUpdateRequest.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/LegalEntityPartnerUpdateRequest.kt
@@ -29,7 +29,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.LegalEntityDto
 
 @JsonDeserialize(using = LegalEntityPartnerUpdateRequest.CustomDeserializer::class)
-@Schema(name = "Legal Entity Update Request", description = "Request for updating a business partner record of type legal entity")
+@Schema(name = "LegalEntityUpdateRequest", description = "Request for updating a business partner record of type legal entity")
 data class LegalEntityPartnerUpdateRequest(
     @Schema(description = "Business Partner Number")
     val bpn: String,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/LegalEntityPropertiesSearchRequest.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/LegalEntityPropertiesSearchRequest.kt
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.boot.context.properties.ConstructorBinding
 
-@Schema(name = "Legal Entity Properties Search Request", description = "Contains keywords used for searching in legal entity properties")
+@Schema(name = "LegalEntityPropertiesSearchRequest", description = "Contains keywords used for searching in legal entity properties")
 data class LegalEntityPropertiesSearchRequest @ConstructorBinding constructor(
     @field:Parameter(description = "Filter legal entities by name")
     val name: String?,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/LegalFormRequest.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/LegalFormRequest.kt
@@ -23,7 +23,7 @@ import com.neovisionaries.i18n.LanguageCode
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.response.type.TypeNameUrlDto
 
-@Schema(name = "Legal Form Request", description = "New legal form record to be referenced by business partners")
+@Schema(name = "LegalFormRequest", description = "New legal form record to be referenced by business partners")
 data class LegalFormRequest(
     @Schema(description = "Unique key to be used for reference")
     val technicalKey: String,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/PaginationRequest.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/PaginationRequest.kt
@@ -25,7 +25,7 @@ import javax.validation.constraints.Max
 import javax.validation.constraints.Min
 import javax.validation.constraints.PositiveOrZero
 
-@Schema(name = "Pagination Request", description = "Defines pagination information for requesting collection results")
+@Schema(name = "PaginationRequest", description = "Defines pagination information for requesting collection results")
 data class PaginationRequest (
     @field:Parameter(
         description = "Number of page to get results from", schema =

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/SitePartnerCreateRequest.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/SitePartnerCreateRequest.kt
@@ -29,7 +29,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.SiteDto
 
 @JsonDeserialize(using = SitePartnerCreateRequest.CustomDeserializer::class)
-@Schema(name = "Site Partner Create Request", description = "Request for creating new business partner record of type site")
+@Schema(name = "SitePartnerCreateRequest", description = "Request for creating new business partner record of type site")
 data class SitePartnerCreateRequest(
     @JsonUnwrapped
     val site: SiteDto,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/SitePartnerUpdateRequest.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/SitePartnerUpdateRequest.kt
@@ -29,7 +29,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.SiteDto
 
 @JsonDeserialize(using = SitePartnerUpdateRequest.CustomDeserializer::class)
-@Schema(name = "Site Partner Update Request", description = "Request for updating a business partner record of type site")
+@Schema(name = "SitePartnerUpdateRequest", description = "Request for updating a business partner record of type site")
 data class SitePartnerUpdateRequest(
     @Schema(description = "Business Partner Number of this site")
     val bpn: String,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/SitePropertiesSearchRequest.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/request/SitePropertiesSearchRequest.kt
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.boot.context.properties.ConstructorBinding
 
-@Schema(name = "Site Properties Search Request", description = "Contains keywords used for searching in site properties")
+@Schema(name = "SitePropertiesSearchRequest", description = "Contains keywords used for searching in site properties")
 data class SitePropertiesSearchRequest @ConstructorBinding constructor(
     @field:Parameter(description = "Filter sites by name")
     val siteName: String?

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/response/AddressPartnerCreateResponse.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/response/AddressPartnerCreateResponse.kt
@@ -29,7 +29,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.response.AddressResponse
 
 @JsonDeserialize(using = AddressPartnerCreateResponse.CustomDeserializer::class)
-@Schema(name = "Address Partner Create Response", description = "Created business partners of type address")
+@Schema(name = "AddressPartnerCreateResponse", description = "Created business partners of type address")
 data class AddressPartnerCreateResponse(
     @Schema(description = "Business Partner Number of this address")
     val bpn: String,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/response/BpnIdentifierMappingResponse.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/response/BpnIdentifierMappingResponse.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(name = "Bpn Identifier Mapping Response", description = "Mapping of Business Partner Number to identifier value")
+@Schema(name = "BpnIdentifierMappingResponse", description = "Mapping of Business Partner Number to identifier value")
 data class BpnIdentifierMappingResponse(
     @Schema(description = "Value of the identifier")
     val idValue: String,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/response/BusinessPartnerResponse.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/response/BusinessPartnerResponse.kt
@@ -32,7 +32,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.SitePartnerResponse
 import java.time.Instant
 
 @JsonDeserialize(using = BusinessPartnerResponse.CustomDeserializer::class)
-@Schema(name = "Business Partner Response", description = "Business Partner of type legal entity in deprecated response format", deprecated = true)
+@Schema(name = "BusinessPartnerResponse", description = "Business Partner of type legal entity in deprecated response format", deprecated = true)
 data class BusinessPartnerResponse(
     val uuid: String,
     @Schema(description = "Business Partner Number, main identifier value for business partners")

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/response/ChangelogEntryResponse.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/response/ChangelogEntryResponse.kt
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.pool.entity.ChangelogType
 import java.time.Instant
 
-@Schema(name = "Changelog Entry Response", description = "Changelog entry for a business partner")
+@Schema(name = "ChangelogEntryResponse", description = "Changelog entry for a business partner")
 data class ChangelogEntryResponse(
     @Schema(description = "Business Partner Number of the changelog entry")
     val bpn: String,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/response/LegalEntityMatchResponse.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/response/LegalEntityMatchResponse.kt
@@ -22,7 +22,7 @@ package org.eclipse.tractusx.bpdm.pool.dto.response
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.response.LegalEntityPartnerResponse
 
-@Schema(name = "Legal Entity Match Response", description = "Match with score for a business partner record of type legal entity")
+@Schema(name = "LegalEntityMatchResponse", description = "Match with score for a business partner record of type legal entity")
 data class LegalEntityMatchResponse(
     @Schema(description = "Relative quality score of the match. The higher the better")
     val score: Float,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/response/LegalEntityPartnerCreateResponse.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/response/LegalEntityPartnerCreateResponse.kt
@@ -31,7 +31,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.LegalEntityResponse
 import java.time.Instant
 
 @JsonDeserialize(using = LegalEntityPartnerCreateResponse.CustomDeserializer::class)
-@Schema(name = "Legal Entity Partner Create Response", description = "Created business partner of type legal entity")
+@Schema(name = "LegalEntityPartnerCreateResponse", description = "Created business partner of type legal entity")
 data class LegalEntityPartnerCreateResponse(
     @Schema(description = "Business Partner Number of this legal entity")
     val bpn: String,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/response/SitePartnerCreateResponse.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/response/SitePartnerCreateResponse.kt
@@ -22,7 +22,7 @@ package org.eclipse.tractusx.bpdm.pool.dto.response
 import io.swagger.v3.oas.annotations.media.Schema
 import org.eclipse.tractusx.bpdm.common.dto.response.AddressResponse
 
-@Schema(name = "Site Partner Create Response", description = "Created business partner record of type site")
+@Schema(name = "SitePartnerCreateResponse", description = "Created business partner record of type site")
 data class SitePartnerCreateResponse(
     @Schema(description = "Business Partner Number, main identifier value for sites")
     val bpn: String,

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/response/SuggestionResponse.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/response/SuggestionResponse.kt
@@ -21,7 +21,7 @@ package org.eclipse.tractusx.bpdm.pool.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(name = "Suggestion Response", description = "Shows a ranked suggestion based on a given search text")
+@Schema(name = "SuggestionResponse", description = "Shows a ranked suggestion based on a given search text")
 data class SuggestionResponse(
     @Schema(description = "The suggestion text")
     val suggestion: String,


### PR DESCRIPTION
- openapi schemas could not be loaded by Invicti DAST scanning tool
- schema names need to match regex ^[a-zA-Z0-9\.\-_]+$
- see open api spec which also specifies this: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.1.md#components-object