### PR TITLE
refactor(openapi): remove even more spaces from schema names

### DIFF
--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/dto/AddressGateInput.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/dto/AddressGateInput.kt
@@ -30,7 +30,7 @@ import org.eclipse.tractusx.bpdm.common.dto.AddressDto
 
 @JsonDeserialize(using = AddressGateInputDeserializer::class)
 @Schema(
-    name = "Address Gate Input", description = "Address with legal entity or site references. " +
+    name = "AddressGateInput", description = "Address with legal entity or site references. " +
             "Only one of either legal entity or site external id can be set for an address."
 )
 data class AddressGateInput(

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/dto/AddressGateOutput.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/dto/AddressGateOutput.kt
@@ -30,7 +30,7 @@ import org.eclipse.tractusx.bpdm.common.dto.response.AddressResponse
 
 @JsonDeserialize(using = AddressGateOutputDeserializer::class)
 @Schema(
-    name = "Address Gate Output", description = "Address with legal entity or site references. " +
+    name = "AddressGateOutput", description = "Address with legal entity or site references. " +
             "Only one of either legal entity or site external id can be set for an address."
 )
 data class AddressGateOutput(

--- a/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/dto/SiteGateInput.kt
+++ b/bpdm-gate/src/main/kotlin/org/eclipse/tractusx/bpdm/gate/dto/SiteGateInput.kt
@@ -30,7 +30,7 @@ import org.eclipse.tractusx.bpdm.common.dto.SiteDto
 
 @JsonDeserialize(using = SiteGateInputDeserializer::class)
 @Schema(
-    name = "Site Gate Input", description = " Site with legal entity reference ."
+    name = "SiteGateInput", description = " Site with legal entity reference ."
 )
 data class SiteGateInput(
     @Schema(description = "Business Partner Number")

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/response/BusinessPartnerMatchResponse.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/dto/response/BusinessPartnerMatchResponse.kt
@@ -22,7 +22,7 @@ package org.eclipse.tractusx.bpdm.pool.dto.response
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(
-    name = "Business Partner Match Response",
+    name = "BusinessPartnerMatchResponse",
     description = "Match with score for a business partner of type legal entity in legacy format",
     deprecated = true
 )


### PR DESCRIPTION
- openapi schemas could not be loaded by Invicti DAST scanning tool
- schema names need to match regex ^[a-zA-Z0-9\.\-_]+$
- see open api spec which also specifies this: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.1.md#components-object