### PR TITLE
fix(db-migration): remove address type LEGAL entries from db

### DIFF
--- a/bpdm-pool/src/main/resources/db/migration/V3_0_0_1__delete_address_type_legal.sql
+++ b/bpdm-pool/src/main/resources/db/migration/V3_0_0_1__delete_address_type_legal.sql
@@ -1,0 +1,1 @@
+delete from address_types where type='LEGAL';


### PR DESCRIPTION
Already manually removed from int/dev dbs but maybe we need it e.g. for pre-prod.