### PR TITLE
chore(github-workflows): update workflows

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -1,10 +1,13 @@
-name: Release core Chart
+name: Release Charts
 
 on:
   workflow_dispatch:
   push:
-    tags:
-      - '*'
+    # prevent unnecessary GH action runs for files outside of charts folder
+    paths:
+      - 'charts/**'
+    branches:
+      - main
 
 jobs:
   release:
@@ -25,11 +28,18 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
-          version: v3.9.1
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update helm dependencies for bpdm-pool
+        run: |
+          cd charts/pool
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add opensearch https://opensearch-project.github.io/helm-charts/
+          helm dependency update
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.0
+        uses: helm/chart-releaser-action@v1.4.1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -32,13 +32,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update helm dependencies for bpdm-pool
-        run: |
-          cd charts/pool
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo add opensearch https://opensearch-project.github.io/helm-charts/
-          helm dependency update
-
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.1
         env:

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/vera-code-full.yaml
+++ b/.github/workflows/vera-code-full.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       #Setup Java 11
       - name: Set up JDK 11


### PR DESCRIPTION
- use v3 everywhere, was still using v2 in some workflows
- align with recommendations from https://catenax-ng.github.io/docs/guides/Helm/how-to-release-a-helm-chart