### PR TITLE
Feat/identifier case insensitive

### DIFF
--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/AddressController.kt
@@ -69,7 +69,7 @@ class AddressController(
 
     @Operation(
         summary = "Get address partners by bpn",
-        description = "Get business partners of type address by bpn-a."
+        description = "Get business partners of type address by bpn-a ignoring case."
     )
     @ApiResponses(
         value = [
@@ -82,7 +82,7 @@ class AddressController(
     fun getAddress(
         @Parameter(description = "Bpn value") @PathVariable bpn: String
     ): AddressPartnerSearchResponse {
-        return addressService.findByBpn(bpn)
+        return addressService.findByBpn(bpn.uppercase())
     }
 
     @Operation(

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BusinessPartnerController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BusinessPartnerController.kt
@@ -41,7 +41,7 @@ class BusinessPartnerController(
 ) {
     @Operation(
         summary = "Get business partner changelog entries by bpn",
-        description = "Get business partner changelog entries by bpn."
+        description = "Get business partner changelog entries by bpn ignoring case."
     )
     @ApiResponses(
         value = [
@@ -55,6 +55,6 @@ class BusinessPartnerController(
         @Parameter(description = "Bpn value") @PathVariable bpn: String,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageResponse<ChangelogEntryResponse> {
-        return partnerChangelogService.getChangelogEntriesByBpn(bpn, paginationRequest.page, paginationRequest.size)
+        return partnerChangelogService.getChangelogEntriesByBpn(bpn.uppercase(), paginationRequest.page, paginationRequest.size)
     }
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BusinessPartnerLegacyController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/BusinessPartnerLegacyController.kt
@@ -99,7 +99,7 @@ class BusinessPartnerLegacyController(
         idType: String?
     ): BusinessPartnerResponse {
         val actualType = idType ?: bpnConfigProperties.id
-        return if (actualType == bpnConfigProperties.id) businessPartnerFetchService.findBusinessPartner(idValue)
-        else businessPartnerFetchService.findBusinessPartner(actualType, idValue)
+        return if (actualType == bpnConfigProperties.id) businessPartnerFetchService.findBusinessPartnerIgnoreCase(idValue)
+        else businessPartnerFetchService.findBusinessPartnerIgnoreCase(actualType, idValue)
     }
 }

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
@@ -103,8 +103,8 @@ class LegalEntityController(
         idType: String?
     ): LegalEntityPartnerResponse {
         val actualType = idType ?: bpnConfigProperties.id
-        return if (actualType == bpnConfigProperties.id) businessPartnerFetchService.findLegalEntity(idValue)
-        else businessPartnerFetchService.findLegalEntity(actualType, idValue)
+        return if (actualType == bpnConfigProperties.id) businessPartnerFetchService.findLegalEntityIgnoreCase(idValue.uppercase())
+        else businessPartnerFetchService.findLegalEntityIgnoreCase(actualType, idValue)
     }
 
     @Operation(

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityController.kt
@@ -110,7 +110,7 @@ class LegalEntityController(
     @Operation(
         summary = "Confirms that the data of a legal entity business partner is still up to date.",
         description = "Confirms that the data of a business partner is still up to date " +
-                "by saving the current timestamp at the time this POST-request is made as this business partner's \"currentness\"."
+                "by saving the current timestamp at the time this POST-request is made as this business partner's \"currentness\". Ignores case of bpn."
     )
     @ApiResponses(
         value = [
@@ -123,7 +123,7 @@ class LegalEntityController(
     fun setLegalEntityCurrentness(
         @Parameter(description = "Bpn value") @PathVariable bpn: String
     ) {
-        businessPartnerBuildService.setBusinessPartnerCurrentness(bpn)
+        businessPartnerBuildService.setBusinessPartnerCurrentness(bpn.uppercase())
     }
 
     @Operation(
@@ -154,7 +154,7 @@ class LegalEntityController(
 
     @Operation(
         summary = "Get site partners of a legal entity",
-        description = "Get business partners of type site belonging to a business partner of type legal entity, identified by the business partner's bpn."
+        description = "Get business partners of type site belonging to a business partner of type legal entity, identified by the business partner's bpn ignoring case."
     )
     @ApiResponses(
         value = [
@@ -168,12 +168,12 @@ class LegalEntityController(
         @Parameter(description = "Bpn value") @PathVariable bpn: String,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageResponse<SitePartnerResponse> {
-        return siteService.findByPartnerBpn(bpn, paginationRequest.page, paginationRequest.size)
+        return siteService.findByPartnerBpn(bpn.uppercase(), paginationRequest.page, paginationRequest.size)
     }
 
     @Operation(
         summary = "Get address partners of a legal entity",
-        description = "Get business partners of type address belonging to a business partner of type legal entity, identified by the business partner's bpn."
+        description = "Get business partners of type address belonging to a business partner of type legal entity, identified by the business partner's bpn ignoring case."
     )
     @ApiResponses(
         value = [
@@ -187,7 +187,7 @@ class LegalEntityController(
         @Parameter(description = "Bpn value") @PathVariable bpn: String,
         @ParameterObject paginationRequest: PaginationRequest
     ): PageResponse<AddressPartnerResponse> {
-        return addressService.findByPartnerBpn(bpn, paginationRequest.page, paginationRequest.size)
+        return addressService.findByPartnerBpn(bpn.uppercase(), paginationRequest.page, paginationRequest.size)
     }
 
     @Operation(

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteController.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/controller/SiteController.kt
@@ -66,7 +66,7 @@ class SiteController(
 
     @Operation(
         summary = "Get site partners by bpn",
-        description = "Get business partners of type site by bpn-s."
+        description = "Get business partners of type site by bpn-s ignoring case."
     )
     @ApiResponses(
         value = [
@@ -79,7 +79,7 @@ class SiteController(
     fun getSite(
         @Parameter(description = "Bpn value") @PathVariable bpn: String
     ): SitePartnerSearchResponse {
-        return siteService.findByBpn(bpn)
+        return siteService.findByBpn(bpn.uppercase())
     }
 
     @Operation(

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/LegalEntityRepository.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/repository/LegalEntityRepository.kt
@@ -37,8 +37,8 @@ interface LegalEntityRepository : PagingAndSortingRepository<LegalEntity, Long>,
 
     fun findByUpdatedAtAfter(updatedAt: Instant, pageable: Pageable): Page<LegalEntity>
 
-    @Query("SELECT DISTINCT i.legalEntity FROM Identifier i WHERE i.type = ?1 AND i.value = ?2")
-    fun findByIdentifierTypeAndValue(type: IdentifierType, idValue: String): LegalEntity?
+    @Query("SELECT DISTINCT i.legalEntity FROM Identifier i WHERE i.type = :type AND upper(i.value) = upper(:idValue)")
+    fun findByIdentifierTypeAndValueIgnoreCase(type: IdentifierType, idValue: String): LegalEntity?
 
     @Query("SELECT DISTINCT p FROM LegalEntity p LEFT JOIN FETCH p.legalForm WHERE p IN :partners")
     fun joinLegalForm(partners: Set<LegalEntity>): Set<LegalEntity>

--- a/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerFetchService.kt
+++ b/bpdm-pool/src/main/kotlin/org/eclipse/tractusx/bpdm/pool/service/BusinessPartnerFetchService.kt
@@ -46,24 +46,24 @@ class BusinessPartnerFetchService(
     /**
      * Fetch a business partner by [bpn] and return as [LegalEntityPartnerResponse]
      */
-    fun findLegalEntity(bpn: String): LegalEntityPartnerResponse {
+    fun findLegalEntityIgnoreCase(bpn: String): LegalEntityPartnerResponse {
         return findOrThrow(bpn).toPoolDto()
     }
 
-    fun findBusinessPartner(bpn: String): BusinessPartnerResponse {
+    fun findBusinessPartnerIgnoreCase(bpn: String): BusinessPartnerResponse {
         return findOrThrow(bpn).toBusinessPartnerDto()
     }
 
     /**
-     * Fetch a business partner by [identifierValue] of [identifierType] and return as [LegalEntityPartnerResponse]
+     * Fetch a business partner by [identifierValue] (ignoring case) of [identifierType] and return as [LegalEntityPartnerResponse]
      */
     @Transactional
-    fun findLegalEntity(identifierType: String, identifierValue: String): LegalEntityPartnerResponse {
+    fun findLegalEntityIgnoreCase(identifierType: String, identifierValue: String): LegalEntityPartnerResponse {
         return findOrThrow(identifierType, identifierValue).toPoolDto()
     }
 
     @Transactional
-    fun findBusinessPartner(identifierType: String, identifierValue: String): BusinessPartnerResponse {
+    fun findBusinessPartnerIgnoreCase(identifierType: String, identifierValue: String): BusinessPartnerResponse {
         return findOrThrow(identifierType, identifierValue).toBusinessPartnerDto()
     }
 
@@ -141,7 +141,10 @@ class BusinessPartnerFetchService(
     fun findOrThrow(identifierType: String, identifierValue: String): LegalEntity {
         val type =
             identifierTypeRepository.findByTechnicalKey(identifierType) ?: throw BpdmNotFoundException(IdentifierType::class.simpleName!!, identifierType)
-        return legalEntityRepository.findByIdentifierTypeAndValue(type, identifierValue) ?: throw BpdmNotFoundException("Identifier Value", identifierValue)
+        return legalEntityRepository.findByIdentifierTypeAndValueIgnoreCase(type, identifierValue) ?: throw BpdmNotFoundException(
+            "Identifier Value",
+            identifierValue
+        )
     }
 
 }

--- a/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerIT.kt
+++ b/bpdm-pool/src/test/kotlin/org/eclipse/tractusx/bpdm/pool/controller/LegalEntityControllerIT.kt
@@ -245,6 +245,137 @@ class LegalEntityControllerIT @Autowired constructor(
 
     /**
      * Given legal entities
+     * When retrieving a legal entity via identifier
+     * Then the legal entity is returned
+     */
+    @Test
+    fun `find legal entities by identifier`() {
+        val givenStructures = listOf(
+            LegalEntityStructureRequest(RequestValues.legalEntityCreate1),
+            LegalEntityStructureRequest(RequestValues.legalEntityCreate2)
+        )
+        val givenLegalEntities = testHelpers.createBusinessPartnerStructure(givenStructures, webTestClient).map { it.legalEntity }
+
+        val expected = givenLegalEntities.map {
+            LegalEntityPartnerResponse(
+                bpn = it.bpn,
+                properties = it.properties,
+                currentness = it.currentness
+            )
+        }.first() // search for first
+
+        val identifierToFind = expected.properties.identifiers.first()
+        val response = webTestClient.invokeGetEndpoint<LegalEntityPartnerResponse>(
+            "${EndpointValues.CATENA_LEGAL_ENTITY_PATH}/${identifierToFind.value}",
+            "idType" to identifierToFind.type.technicalKey
+        )
+
+        assertThat(response)
+            .usingRecursiveComparison()
+            .ignoringCollectionOrder()
+            .ignoringAllOverriddenEquals()
+            .isEqualTo(expected)
+    }
+
+    /**
+     * Given legal entities
+     * When retrieving a legal entity via identifier using a different case
+     * Then the legal entity is returned
+     */
+    @Test
+    fun `find legal entities by identifier case insensitive`() {
+        val givenStructures = listOf(
+            LegalEntityStructureRequest(RequestValues.legalEntityCreate1),
+            LegalEntityStructureRequest(RequestValues.legalEntityCreate2)
+        )
+        val givenLegalEntities = testHelpers.createBusinessPartnerStructure(givenStructures, webTestClient).map { it.legalEntity }
+
+        val expected = givenLegalEntities.map {
+            LegalEntityPartnerResponse(
+                bpn = it.bpn,
+                properties = it.properties,
+                currentness = it.currentness
+            )
+        }.first() // search for first
+
+        var identifierToFind = expected.properties.identifiers.first()
+        identifierToFind = identifierToFind.copy(value = changeCase(identifierToFind.value))
+        val response = webTestClient.invokeGetEndpoint<LegalEntityPartnerResponse>(
+            "${EndpointValues.CATENA_LEGAL_ENTITY_PATH}/${identifierToFind.value}",
+            "idType" to identifierToFind.type.technicalKey
+        )
+
+        assertThat(response)
+            .usingRecursiveComparison()
+            .ignoringCollectionOrder()
+            .ignoringAllOverriddenEquals()
+            .isEqualTo(expected)
+    }
+
+    /**
+     * Given legal entities
+     * When retrieving a legal entity via bpn identifier
+     * Then the legal entity is returned
+     */
+    @Test
+    fun `find legal entities by bpn identifier`() {
+        val givenStructures = listOf(
+            LegalEntityStructureRequest(RequestValues.legalEntityCreate1),
+            LegalEntityStructureRequest(RequestValues.legalEntityCreate2)
+        )
+        val givenLegalEntities = testHelpers.createBusinessPartnerStructure(givenStructures, webTestClient).map { it.legalEntity }
+
+        val expected = givenLegalEntities.map {
+            LegalEntityPartnerResponse(
+                bpn = it.bpn,
+                properties = it.properties,
+                currentness = it.currentness
+            )
+        }.first() // search for first
+
+        val bpnToFind = expected.bpn
+        val response = webTestClient.invokeGetEndpoint<LegalEntityPartnerResponse>("${EndpointValues.CATENA_LEGAL_ENTITY_PATH}/${bpnToFind}")
+
+        assertThat(response)
+            .usingRecursiveComparison()
+            .ignoringCollectionOrder()
+            .ignoringAllOverriddenEquals()
+            .isEqualTo(expected)
+    }
+
+    /**
+     * Given legal entities
+     * When retrieving a legal entity via bpn identifier using a different case
+     * Then the legal entity is returned
+     */
+    @Test
+    fun `find legal entities by bpn identifier case insensitive`() {
+        val givenStructures = listOf(
+            LegalEntityStructureRequest(RequestValues.legalEntityCreate1),
+            LegalEntityStructureRequest(RequestValues.legalEntityCreate2)
+        )
+        val givenLegalEntities = testHelpers.createBusinessPartnerStructure(givenStructures, webTestClient).map { it.legalEntity }
+
+        val expected = givenLegalEntities.map {
+            LegalEntityPartnerResponse(
+                bpn = it.bpn,
+                properties = it.properties,
+                currentness = it.currentness
+            )
+        }.first() // search for first
+
+        val bpnToFind = changeCase(expected.bpn)
+        val response = webTestClient.invokeGetEndpoint<LegalEntityPartnerResponse>("${EndpointValues.CATENA_LEGAL_ENTITY_PATH}/${bpnToFind}")
+
+        assertThat(response)
+            .usingRecursiveComparison()
+            .ignoringCollectionOrder()
+            .ignoringAllOverriddenEquals()
+            .isEqualTo(expected)
+    }
+
+    /**
+     * Given legal entities
      * When retrieving legal entities via BPNLs where some BPNLs exist and others don't
      * Then get those legal entities that could be found
      */
@@ -337,4 +468,12 @@ class LegalEntityControllerIT @Autowired constructor(
         .responseBody
         .blockFirst()!!.currentness
 
+    private fun changeCase(value: String): String {
+        return if (value.uppercase() != value)
+            value.uppercase()
+        else if (value.lowercase() != value)
+            value.lowercase()
+        else
+            throw IllegalArgumentException("Can't change case of string $value")
+    }
 }


### PR DESCRIPTION
Behavior:
If id in route "/legal-entities/{idValue}" is case insensitive, route "/legal-entities/{bpn}/sites" should also be case insensitive.
BUT:
BPN in logic like "PUT /sites" or /search routes is still case sensitive